### PR TITLE
updated docs - deprecated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The philosophy behind Git / Docker tags correlation we ended up using is simple:
 
 Please refer to each tag README.md for full details. To get a quick overview over tags capabilities:
 
-- __Awkward_Aardvark:__ released 2016-07-20. WIP.
+- __Awkward_Aardvark:__ released 2016-07-20. PostgreSQL 9.5.0, PostGIS 2.2.1, GDAL 2.0.2, Patched. Currently our workhorse.
 
 - __PostgreSQL-9.1.2-PostGIS-1.5.8-Patched:__ released a long time ago. A PG 9.1.2 with old PostGIS 1.5.8 patched for handling spanish SRS. For legacy applications.
 
@@ -17,4 +17,4 @@ Please refer to each tag README.md for full details. To get a quick overview ove
 
 - __PostgreSQL-9.4.5-PostGIS-2.2.0-GDAL-2.0.1-Patched:__ released some time ago. The same as above. Legacy.
 
-- __PostgreSQL-9.5.0-PostGIS-2.2.1-GDAL-2.0.2-Patched:__ released 2016-06-15. A lot of configuration options, maybe too much. Currently our workhorse.
+- __PostgreSQL-9.5.0-PostGIS-2.2.1-GDAL-2.0.2-Patched:__ released 2016-06-15. A lot of configuration options, maybe too much. This image is deprecated. Use tag __Awkward Aardvark__ instead.


### PR DESCRIPTION
Tag PostgreSQL-9.5.0-PostGIS-2.2.1-GDAL-2.0.2-Patched is deprecated. Updated in docs.
