### PR TITLE
Decoupled datastore initialization at start up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.tags

--- a/Eclectic_Equidna/Dockerfile
+++ b/Eclectic_Equidna/Dockerfile
@@ -48,9 +48,6 @@ RUN src/compile.sh
 # Port
 EXPOSE 5432
 
-# Volumes
-VOLUME /data
-
 STOPSIGNAL SIGINT
 ENTRYPOINT ["/usr/local/bin/run.sh"]
 

--- a/Eclectic_Equidna/Dockerfile
+++ b/Eclectic_Equidna/Dockerfile
@@ -25,6 +25,7 @@ ADD packages/compile.sh /usr/local/src/
 ADD packages/pg_hba_conf /usr/local/bin
 ADD packages/postgresql_conf /usr/local/bin
 ADD packages/psqlrc /root/.psqlrc
+ADD packages/setup_datastore.sh /usr/local/bin
 ADD https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2 /usr/local/src/
 ADD http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 /usr/local/src/
 ADD http://download.osgeo.org/proj/proj-${PROJ4_VERSION}.tar.gz /usr/local/src/
@@ -41,6 +42,7 @@ ADD https://raw.githubusercontent.com/GeographicaGS/Spanish-Geodetics-Patches/ma
 
 # Compilation
 RUN chmod 777 src/compile.sh
+RUN chmod 777 /usr/local/bin/setup_datastore.sh
 RUN src/compile.sh
 
 # Port

--- a/Eclectic_Equidna/README.md
+++ b/Eclectic_Equidna/README.md
@@ -64,7 +64,7 @@ or pull it from Docker Hub:
 docker pull geographica/postgis:eclectic_equidna
 ```
 
-The image exposes port 5432 and a volume at _/data_ with the data storage.
+The image exposes port 5432.
 
 
 <a name="Container Creation"></a>
@@ -79,7 +79,7 @@ docker run -d -P --name pgcontainer \
 geographica/postgis:eclectic_equidna
 ```
 
-This will create a container with a default volume, __/data__, for storing the data store. The default encoding will be __UTF-8__, and the locale __en_US__. No additional modification or action is taken.
+The default encoding will be __UTF-8__, and the locale __en_US__. No additional modification or action is taken.
 
 Containers can be configured by means of setting environmental variables:
 
@@ -137,7 +137,7 @@ docker run --rm -ti -v /home/malkab/Desktop/:/d --link test_07:pg \ geographica/
 Data Persistence
 ----------------
 
-Datastore data can be persisted in a data volume or host mounted folder and be used later by another container. The container checks if __/data/__ is empty or not. If not, considers the datastore to be not created and creates an empty one.
+Datastore data can be persisted in a data volume or host mounted folder and be used later by another container. The container checks if folder __/data/__ is empty or not. If not, considers the datastore to be not created and creates an empty one.
 
 
 <a name="Passwords"></a>

--- a/Eclectic_Equidna/build.sh
+++ b/Eclectic_Equidna/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --no-cache -t=geographica/postgis:eclectic_equidna .
+docker build -t=geographica/postgis:eclectic_equidna .

--- a/Eclectic_Equidna/packages/run.sh
+++ b/Eclectic_Equidna/packages/run.sh
@@ -18,42 +18,8 @@ log "Locale ${LOCALE}.${ENCODING} generated"
 # Check if command is just "run_default"
 
 if [ "$1" = 'run_default' ]; then
-  log "Running server"
-
-  # Check if data folder is empty. If it is, configure the dataserver
   if [ -z "$(ls -A "/data/")" ]; then
-    log "Initializing datastore..."
-
-    # Create datastore
-    su postgres -c "initdb --encoding=${ENCODING} --locale=${LANG} --lc-collate=${LANG} --lc-monetary=${LANG} --lc-numeric=${LANG} --lc-time=${LANG} -D /data/"
-
-    log "Datastore created..."
-
-    # Create log folder
-    mkdir -p /data/logs
-    chown postgres:postgres /data/logs
-
-    log "Log folder created..."
-
-    # Erase default configuration and initialize it
-    su postgres -c "rm /data/pg_hba.conf"
-    su postgres -c "pg_hba_conf a \"${PG_HBA}\""
-
-    # Modify basic configuration
-    su postgres -c "rm /data/postgresql.conf"
-    PG_CONF="${PG_CONF}#lc_messages='${LANG}'#lc_monetary='${LANG}'#lc_numeric='${LANG}'#lc_time='${LANG}'"
-    su postgres -c "postgresql_conf a \"${PG_CONF}\""
-
-    # Establish postgres user password and run the database
-    su postgres -c "pg_ctl -w -D /data/ start"
-    su postgres -c "psql -h localhost -U postgres -p 5432 -c \"alter role postgres password '${POSTGRES_PASSWD}';\""
-
-    log "Configurating and adding postgres user to the database..."
-
-    log "Stopping the server..."
-
-    # Stop the server
-    su postgres -c "pg_ctl -w -D /data/ stop"
+    /usr/local/bin/setup_datastore.sh
   else
     log "Datastore already exists..."
   fi

--- a/Eclectic_Equidna/packages/run.sh
+++ b/Eclectic_Equidna/packages/run.sh
@@ -29,5 +29,7 @@ if [ "$1" = 'run_default' ]; then
   # Start the database
   exec gosu postgres postgres -D /data/
 else
+  log "Executing custom command ${1}"
+
   exec env "$@"
 fi

--- a/Eclectic_Equidna/packages/setup_datastore.sh
+++ b/Eclectic_Equidna/packages/setup_datastore.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+log(){
+    echo "$(date +"%Y-%m-%d %T") > $1" >> /log.txt
+}
+
+# Generate locale
+LANG=${LOCALE}.${ENCODING}
+
+locale-gen ${LANG} > /dev/null
+
+log "Locale ${LOCALE}.${ENCODING} generated"
+
+log "Running server"
+
+# Check if data folder is empty. If it is, configure the dataserver
+log "Initializing datastore..."
+
+# Create datastore
+su postgres -c "initdb --encoding=${ENCODING} --locale=${LANG} --lc-collate=${LANG} --lc-monetary=${LANG} --lc-numeric=${LANG} --lc-time=${LANG} -D /data/"
+
+log "Datastore created..."
+
+# Create log folder
+mkdir -p /data/logs
+chown postgres:postgres /data/logs
+
+log "Log folder created..."
+
+# Erase default configuration and initialize it
+su postgres -c "rm /data/pg_hba.conf"
+su postgres -c "pg_hba_conf a \"${PG_HBA}\""
+
+# Modify basic configuration
+su postgres -c "rm /data/postgresql.conf"
+PG_CONF="${PG_CONF}#lc_messages='${LANG}'#lc_monetary='${LANG}'#lc_numeric='${LANG}'#lc_time='${LANG}'"
+su postgres -c "postgresql_conf a \"${PG_CONF}\""
+
+# Establish postgres user password and run the database
+su postgres -c "pg_ctl -w -D /data/ start"
+su postgres -c "psql -h localhost -U postgres -p 5432 -c \"alter role postgres password '${POSTGRES_PASSWD}';\""
+
+log "Configurating and adding postgres user to the database..."
+
+log "Stopping the server..."
+
+# Stop the server
+su postgres -c "pg_ctl -w -D /data/ stop"

--- a/Eclectic_Equidna/push.sh
+++ b/Eclectic_Equidna/push.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker login
+docker push geographica/postgis:eclectic_equidna

--- a/Eclectic_Equidna/run.sh
+++ b/Eclectic_Equidna/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -ti --rm geographica/postgis:eclectic_equidna


### PR DESCRIPTION
Datastore initialization has been decoupled from the container start up procedure in script packages/setup_datastore.sh, so it can be used to initialize the datastore before container creation, for example at image creation during the image build process to restore database dumps and other operations. The goal is to provide database data ready containers in production deployment scenarios.